### PR TITLE
add MAV_CMD_COMPONENT_CONTROL cmd and COMPONENT_CONTROL enum

### DIFF
--- a/message_definitions/v1.0/ras_a.xml
+++ b/message_definitions/v1.0/ras_a.xml
@@ -169,7 +169,7 @@
         <param index="6" label="Y2 or Longitude 2">Local Y (mE4) or Longitude (degE7) (WGS84) (depending on MAV_FRAME) of point 2 of the exploration 3D space boundaries cuboid. INT32_MAX if not applicable.</param>
         <param index="7" label="Z3 or Altitude 3" units="m">Local Z or Altitude (MSL) (depending on MAV_FRAME) point 3 of the exploration 3D space boundaries cuboid. This also represents the height of the bottom plane of the cuboid. NaN if not applicable.</param>
       </entry>
-      <entry value="51015" name="MAV_CMD_SET_POI_FOCUS" hasLocation="false" isDestination="false">
+      <entry value="51020" name="MAV_CMD_SET_POI_FOCUS" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This command is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Sets a POI at the current focus point of the camera frame. This assumes that the camera system has the ability to geo-locate the current focus point.</description>
@@ -177,7 +177,7 @@
         <param index="2" label="X Position in the camera frame" minValue="0" increment="1">Position given by the number of pixels in X direction of the camera frame. Origin on the bottom left corner of the camera frame.</param>
         <param index="3" label="Y Position in the camera frame" minValue="0" increment="1">Position given by the number of pixels in Y direction of the camera frame. Origin on the bottom left corner of the camera frame.</param>
       </entry>
-      <entry value="51016" name="MAV_CMD_DO_FOLLOW_POI" hasLocation="false" isDestination="false">
+      <entry value="51021" name="MAV_CMD_DO_FOLLOW_POI" hasLocation="false" isDestination="false">
         <wip/>
         <!-- This command is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
         <description>Invoke platform to begin following a POI as a subject</description>

--- a/message_definitions/v1.0/ras_a.xml
+++ b/message_definitions/v1.0/ras_a.xml
@@ -187,6 +187,18 @@
         <param index="4" label="Subject Follow Distance" units="m">Distance in 3D meters to attempt to maintain from target subject</param>
         <param index="5" label="Subject Follow Bearing" units="deg">Bearing in degrees from POI to attempt to maintain</param>
       </entry>
+      <entry value="51050" name="MAV_CMD_COMPONENT_CONTROL" hasLocation="false" isDestination="false">
+        <wip/>
+        <!-- This command is work-in-progress and it can therefore change. It should NOT be used in stable production environments. -->
+        <description>Control the state or functionality of system components.</description>
+        <param index="1" label="Component ID" enum="MAV_COMPONENT">Component ID of the system component to be controlled.</param>
+        <param index="2" label="Component Control Type" enum="COMPONENT_CONTROL">Control command type being sent to the system component.</param>
+        <param index="3" label="Component Instance ID" minValue="0" maxValue="255" increment="1">Identifier for the component instance. It matches an internal mapping on the system to a component/service/process ID. This is applicable when there exists a system/service manager that handles this command and interfaces with components and its instances, or when the component itself is aware of its instance number (when the target component of the command is the component to control). If there is only one instance of the component, or when one wants to control all the instances of the component, set the field to 0.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
     </enum>
     <enum name="POI_GEOMETRY_TYPE">
       <description>Point-of-Interest geometry types.</description>
@@ -383,6 +395,27 @@
       </entry>
       <entry value="3" name="TRIPOD">
         <description>Platform stays stationary but its sensors follow the subject.  Ignores subject_follow_dist and subject_follow_bearing</description>
+      </entry>
+    </enum>
+    <enum name="COMPONENT_CONTROL">
+      <description>Type of controls or state changes for system components.</description>
+      <entry value="1" name="COMPONENT_CONTROL_START">
+        <description>Start/turn-on system component.</description>
+      </entry>
+      <entry value="2" name="COMPONENT_CONTROL_STOP">
+        <description>Stop/turn-off system component.</description>
+      </entry>
+      <entry value="3" name="COMPONENT_CONTROL_RESTART">
+        <description>Restart/reboot system component.</description>
+      </entry>
+      <entry value="4" name="COMPONENT_CONTROL_RESTART_AND_KEEP_BL">
+        <description>Restart/reboot system component and keep it in the bootloader until upgraded.</description>
+      </entry>
+      <entry value="5" name="COMPONENT_CONTROL_ENABLE">
+        <description>Enable system component. Used to switch a system component from an idle state to an active state.</description>
+      </entry>
+      <entry value="6" name="COMPONENT_CONTROL_DISABLE">
+        <description>Disable system component. Used to switch a system component from an active state to an idle state.</description>
       </entry>
     </enum>
   </enums>


### PR DESCRIPTION
This PR adds `MAV_CMD_COMPONENT_CONTROL`, a command that serves the purpose of controlling system components with an exposed MAVLink interface. We can compare it with simplified version of `systemctl`, which is an utility that makes part of Linux `systemd`, but in this case it can interface with both HW components and also with system services identified by component ID (ex: `MAV_COMP_ID_PATHPLANNER` or `MAV_COMP_ID_OBSTACLE_AVOIDANCE`). **A new component for the Autonomy Engine should be added as well** (as a follow-up to this PR).

The type of control that can be used is mapped by the `COMPONENT_CONTROL` enumeration, which can be extended for other types of controls if required.

This command can be considered a replacement of `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN`, as it provided more control options without restricting ourselves the the limited command fields.